### PR TITLE
Fix same type ores generated by multiple mods

### DIFF
--- a/overrides/config/forestry/common.cfg
+++ b/overrides/config/forestry/common.cfg
@@ -1,0 +1,263 @@
+# Configuration file
+
+~CONFIG_VERSION: 1.2.0
+
+crafting {
+    # Enables the crafting recipe for bronze. [default: true]
+    B:bronze=true
+
+    stamps {
+        # Disables the crafting recipe for certain stamps. [default: [20n, 50n, 100n]] [valid: [1n, 2n, 5n, 10n, 20n, 50n, 100n]]
+        S:disabled <
+            20n
+            50n
+            100n
+         >
+
+        # Enables the crafting recipe for stamps. Disable to use stamps as a currency. [default: true]
+        B:enabled=true
+    }
+
+}
+
+
+debug {
+    # Enable Debug mode (only useful to developers). [default: false]
+    B:enabled=false
+}
+
+
+difficulty {
+    # Set to your preferred game mode. Mismatch with the server may cause visual glitches with recipes. [default: EASY] [valid: [OP, EASY, NORMAL, HARD]]
+    S:game.mode=EASY
+
+    # Forces recreation of the game mode definitions in config/forestry/gamemodes.
+    B:recreate.definitions=false
+}
+
+
+genetics {
+    #  [range: 0 ~ 100000, default: 20320]
+    I:analyzerblock.energy.use=20320
+
+    # Allow bees to pollinate vanilla tree leaves. When disabled, vanilla trees must be analyzed before they can be pollinated. [default: true]
+    B:pollinate.vanilla.trees=true
+
+    research {
+
+        boost {
+            # The maximum percentage boost that can be applied by researching a mutation in the Escritoire. [range: 0.0 ~ 100.0, default: 5.0]
+            S:max.percent=5.0
+
+            # Multiplies the chance of a mutation when it has been discovered in the Escritoire. [range: 1.0 ~ 1000.0, default: 1.5]
+            S:multiplier=1.5
+        }
+
+    }
+
+}
+
+
+performance {
+    # Enable backpack resupply. You may want to set this to false on busy servers. [default: true]
+    B:backpacks.resupply=true
+
+    # Enables particle effects. Note that Forestry respects Minecraft's reduced particle video settings. [default: true]
+    B:particleFX=true
+}
+
+
+structures {
+    # List specific structures to disable them. [default: []] [valid: [alveary3x3, farm3x3, farm3x4, farm3x5, farm4x4, farm5x5]]
+    S:disabled <
+     >
+}
+
+
+tweaks {
+
+    humus {
+        # Set how many stages humus has before it turns into sand. [range: 1 ~ 10, default: 3]
+        I:degradeDelimiter=3
+    }
+
+    gui {
+
+        mail {
+
+            alert {
+                # Enables the new mail alert box. [default: true]
+                B:enabled=true
+
+                # Horizontal Position of the mail alert box on the screen. [default: LEFT] [valid: [LEFT, RIGHT]]
+                S:xPosition=LEFT
+
+                # Vertical Position of the mail alert box on the screen. [default: TOP] [valid: [TOP, BOTTOM]]
+                S:yPosition=TOP
+            }
+
+        }
+
+        tabs {
+            # Display the energy statistics tab on energy consumers. [default: true]
+            B:energy=true
+
+            # Enables the hints tab on machine and engine guis. [default: true]
+            B:hints=true
+
+            # Set the speed at which the gui side tabs open and close. [range: 1 ~ 50, default: 8]
+            I:speed=8
+        }
+
+    }
+
+    farms {
+        # Enables farm support for Extra Utilities Ender-lily seeds. [default: true]
+        B:enderlily=true
+
+        # Sets the multiplier of the multifarm and the cultivation farms. All cultivation farms alway use the double amount of fertilizer. [range: 0.1 ~ 5.0, default: 1.0]
+        S:fertilizer=1.0
+
+        # Enables farm support for Magical Crops. [default: true]
+        B:magicalcrops=true
+
+        # Enables farm support for Extra Utilities Red Orchid. [default: true]
+        B:redorchid=true
+
+        # Sets the size multiplier of the farmland. [range: 1 ~ 3, default: 2]
+        I:size=2
+
+        # Makes farms use a square layout instead of a diamond one. [default: false]
+        B:square=false
+    }
+
+    cultivation {
+        # Sets the size of the farmland that is used by all cultivation farms. [range: 1 ~ 15, default: 4]
+        I:extend=4
+
+        # Makes cultivation farms use a ring layout like the layout of the old farms. The farmland size of the ring layout is always one block smaller. [default: true]
+        B:ring=true
+
+        # Sets the size of the inner ring of the ring layout. [range: 1 ~ 8, default: 4]
+        I:ring_size=4
+    }
+
+    capsule {
+        # Enables the function that cans and capsules can pick up fluids from the world. [default: false]
+        B:capsulePickup=false
+
+        # Capsules are no longer consumed after being emptied. [default: false]
+        B:capsuleReuseable=false
+    }
+
+    greenhouse {
+        # Modifies the energy that is used by the greenhouse climatisers. [range: 0.0 ~ 15.0, default: 1.5]
+        S:energy=1.5
+
+        # Set the range divisor of the climatiser of the greenhouse. [range: 9 ~ 270, default: 36]
+        I:range=36
+
+        # Set the size multiplier of the climated blocks. [range: 1 ~ 5, default: 4]
+        I:size=4
+    }
+
+    book {
+        # Players who enter the world for the first time get a Forester's Manual. [default: true]
+        B:spawn=true
+    }
+
+}
+
+
+world {
+
+    generate {
+        #  [default: true]
+        B:trees=true
+
+        # Generates Forestry villagers and their houses. [default: true]
+        B:villagers=true
+
+        retrogen {
+            # Creates Forestry world generation in all chunks, even if they were generated there before. [default: false]
+            B:forced=false
+
+            # Creates Forestry world generation in chunks that were created before the mod was added. [default: false]
+            B:normal=false
+        }
+
+        beehives {
+            # Sets how many beehives spawn in the world. [range: 0.0 ~ 10.0, default: 1.0]
+            S:amount=1.0
+
+            # Force Forestry to generate a beehive at every possible location. (This will break your world. Only useful to developers) [default: false]
+            B:debug=false
+            I:dimBlacklist <
+             >
+            I:dimWhitelist <
+             >
+
+            ##########################################################################################################
+            # blacklist
+            #--------------------------------------------------------------------------------------------------------#
+            # Disables the generation of a specific hive in a specific biome or in a biome with a specific biome
+            # type. Just add the registry name of the biome or the name of the biome type to the property of the
+            # hive. Every biome type / registry name has to be in a seperate line. The global type can be used to
+            # blacklist a biome from all hive generation.
+            ##########################################################################################################
+
+            blacklist {
+                S:desert <
+                 >
+                S:end <
+                 >
+                S:forest <
+                 >
+                S:global <
+                 >
+                S:jungle <
+                 >
+                S:meadows <
+                 >
+                S:snow <
+                 >
+                S:swamp <
+                 >
+                S:swarm <
+                 >
+            }
+
+        }
+
+        ore {
+            # Generates apatite ore blocks in the world. [default: true]
+            B:apatite=true
+
+            # Generates copper ore blocks in the world. [default: true]
+            B:copper=false
+            I:dimBlacklist <
+             >
+            I:dimWhitelist <
+             >
+
+            # Generates tin ore blocks in the world. [default: true]
+            B:tin=false
+        }
+
+        trees {
+            S:biomeblacklist <
+             >
+            I:dimBlacklist <
+             >
+            I:dimWhitelist <
+             >
+
+            # How Frequently forestry generates it's trees in the world [range: 0.0 ~ 10.0, default: 1.0]
+            S:treeFrequency=1.0
+        }
+
+    }
+
+}
+
+

--- a/overrides/config/immersiveengineering.cfg
+++ b/overrides/config/immersiveengineering.cfg
@@ -383,7 +383,7 @@ general {
         # Generation config for Bauxite Ore.
         # Parameters: Vein size, lowest possible Y, highest possible Y, veins per chunk, chance for vein to spawn (out of 100). Set vein size to 0 to disable the generation
         I:ore_bauxite <
-            4
+            0
             40
             85
             8

--- a/overrides/config/immersiveengineering.cfg
+++ b/overrides/config/immersiveengineering.cfg
@@ -1,0 +1,555 @@
+# Configuration file
+
+general {
+    # Set this to false to disable the manual's forced change of GUI scale
+    B:adjustManualScale=false
+
+    # Set this to true if you suffer from bad eyesight. The Engineer's manual will be switched to a bold and darker text to improve readability.
+    # Note that this may lead to a break of formatting and have text go off the page in some instances. This is unavoidable.
+    B:badEyesight=false
+
+    # If this is enabled, placing a block in a wire will break it (drop the wire coil)
+    B:blocksBreakWires=true
+
+    # Support for colourblind people, gives a text-based output on capacitor sides
+    B:colourblindSupport=false
+
+    # Disables most lighting code for certain models that are rendered dynamically (TESR). May improve FPS.
+    # Affects turrets and garden cloches
+    B:disableFancyTESR=false
+
+    # A config setting to enable debug features. These features may vary between releases, may cause crashes, and are unsupported. Do not enable unless asked to by a developer of IE.
+    B:enableDebug=false
+
+    # Set this to false to remove IE villagers from the game
+    B:enableVillagers=true
+
+    # If this is enabled, wires connected to power sources will cause damage to entities touching them
+    # This shouldn't cause significant lag but possibly will. If it does, please report it at https://github.com/BluSunrize/ImmersiveEngineering/issues unless there is a report of it already.
+    B:enableWireDamage=true
+
+    # Allows revolvers and other IE items to look properly held in 3rd person. This uses a coremod. Can be disabled in case of conflicts with other animation mods.
+    B:fancyItemHolding=true
+
+    # The weight that hempseeds have when breaking tall grass. 5 by default, set to 0 to disable drops
+    I:hempSeedWeight=5
+
+    # By default all devices that accept cables have increased renderbounds to show cables even if the block itself is not in view.
+    # Disabling this reduces them to their minimum sizes, which might improve FPS on low-power PCs
+    B:increasedRenderboxes=true
+
+    # Increase the distance at which certain TileEntities (specifically windmills) are still visible. This is a modifier, so set it to 1 for default render distance, to 2 for doubled distance and so on.
+    D:increasedTileRenderdistance=1.5
+
+    # Set this to false to disable the super awesome looking nixie tube front for the voltmeter and other things
+    B:nixietubeFont=true
+
+    # Controls if item tooltips should contain the OreDictionary names of items. These tooltips are only visible in advanced tooltip mod (F3+H)
+    B:oreTooltips=true
+
+    # A list of preferred Mod IDs that results of IE processes should stem from, aka which mod you want the copper to come from.
+    # This affects the ores dug by the excavator, as well as those crushing recipes that don't have associated IE items. This list is in oreder of priority.
+    S:preferredOres <
+        thermalfoundation
+        immersiveengineering
+     >
+
+    # Set this to false to hide the update news in the manual
+    B:showUpdateNews=true
+
+    # Drop connections with non-existing endpoints when loading the world. Use with care and backups and only when suspecting corrupted data.
+    # This option will check and load all connection endpoints and may slow down the world loading process.
+    B:validateConnections=false
+
+    # Set this to false to stop the IE villager house from spawning
+    B:villagerHouse=true
+
+    # The RGB colourate of the wires.
+    I:wireColouration <
+        11758655
+        15573061
+        7303023
+        9862765
+        7303023
+        16723759
+        16445918
+        10323322
+     >
+    I:wireColourationDefault <
+        11758655
+        15573061
+        7303023
+        9862765
+        7303023
+        16723759
+        16445918
+        10323322
+     >
+
+    # The maximum length wire can have. Copper and Electrum should be similar, Steel is meant for long range transport, Structural Rope & Cables are purely decorational
+    I:wireLength <
+        16
+        16
+        32
+        32
+        32
+        32
+     >
+
+    # The percentage of power lost every 16 blocks of distance for the wire tiers (copper, electrum, HV, Structural Rope, Cable & Redstone(no transfer) )
+    D:wireLossRatio <
+        0.05
+        0.025
+        0.025
+        1.0
+        1.0
+        1.0
+     >
+
+    # The transfer rates in Flux/t for the wire tiers (copper, electrum, HV, Structural Rope, Cable & Redstone(no transfer) )
+    I:wireTransferRate <
+        2048
+        8192
+        32768
+        0
+        0
+        0
+     >
+
+    ##########################################################################################################
+    # compat
+    #--------------------------------------------------------------------------------------------------------#
+    # A list of all mods that IE has integrated compatability for
+    # Setting any of these to false disables the respective compat
+    ##########################################################################################################
+
+    compat {
+        B:actuallyadditions=true
+        B:albedo=true
+        B:attaineddrops=true
+        B:baubles=true
+        B:betterwithmods=true
+        B:bloodmagic=true
+        B:botania=true
+        B:chisel=true
+        B:chiselsandbits=true
+        B:cofhcore=true
+        B:crafttweaker=true
+        B:denseores=true
+        B:enderio=true
+        B:extrautils2=true
+        B:forestry=true
+        B:foundry=true
+        B:harvestcraft=true
+        B:ic2=true
+        B:mysticalagriculture=true
+        B:opencomputers=true
+        B:railcraft=true
+        B:tconstruct=true
+        B:thaumcraft=true
+        B:theoneprobe=true
+        B:thermalfoundation=true
+        B:waila=true
+    }
+
+    machines {
+        # A modifier to apply to the energy costs of every Arc Furnace recipe
+        D:arcFurnace_energyModifier=1.0
+
+        # A modifier to apply to the time of every Arc Furnace recipe
+        D:arcFurnace_timeModifier=1.0
+
+        # Set this to true to make the blueprint for graphite electrodes craftable in addition to villager/dungeon loot
+        B:arcfurnace_electrodeCrafting=false
+
+        # The maximum amount of damage Graphite Electrodes can take. While the furnace is working, electrodes sustain 1 damage per tick, so this is effectively the lifetime in ticks. The default value of 96000 makes them last for 8 consecutive ingame days
+        I:arcfurnace_electrodeDamage=96000
+
+        # Set this to false to disable the Arc Furnace's recycling of armors and tools
+        B:arcfurnace_recycle=true
+
+        # The Flux the Assembler will consume to craft an item from a recipe
+        I:assembler_consumption=80
+
+        # A modifier to apply to the energy costs of every Automatic Workbench recipe
+        D:autoWorkbench_energyModifier=1.0
+
+        # A modifier to apply to the time of every Automatic Workbench recipe
+        D:autoWorkbench_timeModifier=1.0
+
+        # The Flux per tick the belljar consumes to grow plants
+        I:belljar_consumption=8
+
+        # The amount of ticks one dose of fertilizer lasts in the belljar
+        I:belljar_fertilizer=6000
+
+        # The amount of fluid the belljar uses per dose of fertilizer
+        I:belljar_fluid=250
+
+        # A base-modifier for all fluid fertilizers in the belljar
+        D:belljar_fluid_fertilizer_mod=1.0
+
+        # A modifier to apply to the belljars total growing speed
+        D:belljar_growth_mod=1.0
+
+        # A base-modifier for all solid fertilizers in the belljar
+        D:belljar_solid_fertilizer_mod=1.0
+
+        # A modifier to apply to the energy costs of every Bottling Machine's process
+        D:bottlingMachine_energyModifier=1.0
+
+        # A modifier to apply to the time of every Bottling Machine's process
+        D:bottlingMachine_timeModifier=1.0
+
+        # The maximum amount of Flux that can be input into a high-voltage capacitor (by IE net or other means)
+        I:capacitorHV_input=4096
+
+        # The maximum amount of Flux that can be output from a high-voltage capacitor (by IE net or other means)
+        I:capacitorHV_output=4096
+
+        # The maximum amount of Flux that can be stored in a high-voltage capacitor
+        I:capacitorHV_storage=4000000
+
+        # The maximum amount of Flux that can be input into a low-voltage capacitor (by IE net or other means)
+        I:capacitorLV_input=256
+
+        # The maximum amount of Flux that can be output from a low-voltage capacitor (by IE net or other means)
+        I:capacitorLV_output=256
+
+        # The maximum amount of Flux that can be stored in a low-voltage capacitor
+        I:capacitorLV_storage=100000
+
+        # The maximum amount of Flux that can be input into a medium-voltage capacitor (by IE net or other means)
+        I:capacitorMV_input=1024
+
+        # The maximum amount of Flux that can be output from a medium-voltage capacitor (by IE net or other means)
+        I:capacitorMV_output=1024
+
+        # The maximum amount of Flux that can be stored in a medium-voltage capacitor
+        I:capacitorMV_storage=1000000
+
+        # The Flux per tick the Charging Station can insert into an item
+        I:charger_consumption=256
+
+        # The Flux per tick consumed by the Core Sample Drill
+        I:coredrill_consumption=40
+
+        # The length in ticks it takes for the Core Sample Drill to figure out which mineral is found in a chunk
+        I:coredrill_time=200
+
+        # A modifier to apply to the energy costs of every Crusher recipe
+        D:crusher_energyModifier=1.0
+
+        # A modifier to apply to the time of every Crusher recipe
+        D:crusher_timeModifier=1.0
+
+        # The Flux per tick that the Diesel Generator will output. The burn time of the fuel determines the total output
+        I:dieselGen_output=4096
+
+        # The base Flux that is output by the dynamo. This will be modified by the rotation modifier of the attached water- or windmill
+        D:dynamo_output=3.0
+
+        # The chance that a given chunk will contain a mineral vein.
+        D:excavator_chance=0.2
+
+        # The Flux per tick the Excavator will consume to dig
+        I:excavator_consumption=4096
+
+        # The maximum amount of yield one can get out of a chunk with the excavator. Set a number smaller than zero to make it infinite
+        I:excavator_depletion=38400
+
+        # List of dimensions that can't contain minerals. Default: The End.
+        I:excavator_dimBlacklist <
+            1
+         >
+
+        # The chance that the Excavator will not dig up an ore with the currently downward-facing bucket.
+        D:excavator_fail_chance=0.05
+
+        # Set this to false to disable the ridiculous amounts of particles the Excavator spawns
+        B:excavator_particles=true
+
+        # The speed of the Excavator. Basically translates to how many degrees per tick it will turn.
+        D:excavator_speed=1.0
+
+        # A modifier to apply to the energy costs of every Fermenter recipe
+        D:fermenter_energyModifier=1.0
+
+        # A modifier to apply to the time of every Fermenter recipe
+        D:fermenter_timeModifier=1.0
+
+        # How much Flux the floodlight draws per tick
+        I:floodlight_energyDraw=5
+
+        # How much Flux the floodlight can hold (must be at least 10x the power draw)
+        I:floodlight_maximumStorage=80
+
+        # Set this to false to disable the mob-spawn prevention of the Floodlight
+        B:floodlight_spawnPrevent=true
+
+        # The Flux per tick consumed to add one heat to a furnace. Creates up to 4 heat in the startup time and then 1 heat per tick to keep it running
+        I:heater_consumption=8
+
+        # The Flux per tick consumed to double the speed of the furnace. Only happens if furnace is at maximum heat.
+        I:heater_speedupConsumption=24
+
+        # How much Flux the powered lantern draws per tick
+        I:lantern_energyDraw=1
+
+        # How much Flux the powered lantern can hold (should be greater than the power draw)
+        I:lantern_maximumStorage=10
+
+        # Set this to false to disable the mob-spawn prevention of the Powered Lantern
+        B:lantern_spawnPrevent=true
+
+        # The Flux that will be output by the lightning rod when it is struck
+        I:lightning_output=16000000
+
+        # A modifier to apply to the energy costs of every MetalPress recipe
+        D:metalPress_energyModifier=1.0
+
+        # A modifier to apply to the time of every MetalPress recipe
+        D:metalPress_timeModifier=1.0
+
+        # A modifier to apply to the energy costs of every Mixer's process
+        D:mixer_energyModifier=1.0
+
+        # A modifier to apply to the time of every Mixer's process
+        D:mixer_timeModifier=1.0
+
+        # The Flux per tick the Blast Furnace Preheater will consume to speed up the Blast Furnace
+        I:preheater_consumption=32
+
+        # The Flux the Fluid Pump will consume to pick up a fluid block in the world
+        I:pump_consumption=250
+
+        # The Flux the Fluid Pump will consume pressurize+accellerate fluids, increasing the transferrate
+        I:pump_consumption_accelerate=5
+
+        # Set this to false to disable the fluid pump being able to draw infinite water from sources
+        B:pump_infiniteWater=true
+
+        # If this is set to true (default) the pump will replace fluids it picks up with cobblestone in order to reduce lag caused by flowing fluids.
+        B:pump_placeCobble=true
+
+        # A modifier to apply to the energy costs of every Refinery recipe
+        D:refinery_energyModifier=1.0
+
+        # A modifier to apply to the time of every Refinery recipe. Can't be lower than 1
+        D:refinery_timeModifier=1.0
+
+        # A modifier to apply to the energy costs of every Squeezer recipe
+        D:squeezer_energyModifier=1.0
+
+        # A modifier to apply to the time of every Squeezer recipe
+        D:squeezer_timeModifier=1.0
+
+        # The Flux per tick the Tesla Coil will consume, simply by being active
+        I:teslacoil_consumption=256
+
+        # The amount of Flux the Tesla Coil will consume when shocking an entity
+        I:teslacoil_consumption_active=512
+
+        # The amount of damage the Tesla Coil will do when shocking an entity
+        D:teslacoil_damage=6.0
+
+        # Output modifier for the energy created by the Thermoelectric Generator
+        D:thermoelectric_output=1.0
+
+        # The Flux per tick the chemthrower turret consumes to shoot
+        I:turret_chem_consumption=32
+
+        # The Flux per tick any turret consumes to monitor the area
+        I:turret_consumption=64
+
+        # The Flux per tick the gun turret consumes to shoot
+        I:turret_gun_consumption=32
+
+        # In- and output rates of LV,MV and HV Wire Conenctors. This is independant of the transferrate of the wires.
+        I:wireConnectorInput <
+            256
+            1024
+            4096
+         >
+    }
+
+    ores {
+        # A blacklist of dimensions in which IE ores won't spawn. By default this is Nether (-1) and End (1)
+        I:oreDimBlacklist <
+            -1
+            1
+         >
+
+        # Generation config for Bauxite Ore.
+        # Parameters: Vein size, lowest possible Y, highest possible Y, veins per chunk, chance for vein to spawn (out of 100). Set vein size to 0 to disable the generation
+        I:ore_bauxite <
+            4
+            40
+            85
+            8
+            100
+         >
+
+        # Generation config for Copper Ore.
+        # Parameters: Vein size, lowest possible Y, highest possible Y, veins per chunk, chance for vein to spawn (out of 100). Set vein size to 0 to disable the generation
+        I:ore_copper <
+            0
+            40
+            72
+            8
+            100
+         >
+
+        # Generation config for Lead Ore.
+        # Parameters: Vein size, lowest possible Y, highest possible Y, veins per chunk, chance for vein to spawn (out of 100). Set vein size to 0 to disable the generation
+        I:ore_lead <
+            0
+            8
+            36
+            4
+            100
+         >
+
+        # Generation config for Nickel Ore.
+        # Parameters: Vein size, lowest possible Y, highest possible Y, veins per chunk, chance for vein to spawn (out of 100). Set vein size to 0 to disable the generation
+        I:ore_nickel <
+            0
+            8
+            24
+            2
+            100
+         >
+
+        # Generation config for Silver Ore.
+        # Parameters: Vein size, lowest possible Y, highest possible Y, veins per chunk, chance for vein to spawn (out of 100). Set vein size to 0 to disable the generation
+        I:ore_silver <
+            0
+            8
+            40
+            4
+            80
+         >
+
+        # Generation config for Uranium Ore.
+        # Parameters: Vein size, lowest possible Y, highest possible Y, veins per chunk, chance for vein to spawn (out of 100). Set vein size to 0 to disable the generation
+        I:ore_uranium <
+            4
+            8
+            24
+            2
+            60
+         >
+
+        # Set this to true to allow retro-generation of Bauxite Ore.
+        B:retrogen_bauxite=false
+
+        # Set this to true to allow retro-generation of Copper Ore.
+        B:retrogen_copper=false
+
+        # The retrogeneration key. Basically IE checks if this key is saved in the chunks data. If it isn't, it will perform retrogen on all ores marked for retrogen.
+        # Change this in combination with the retrogen booleans to regen only some of the ores.
+        S:retrogen_key=DEFAULT
+
+        # Set this to true to allow retro-generation of Lead Ore.
+        B:retrogen_lead=false
+
+        # Set this to false to disable the logging of the chunks that were flagged for retrogen.
+        B:retrogen_log_flagChunk=true
+
+        # Set this to false to disable the logging of the chunks that are still left to retrogen.
+        B:retrogen_log_remaining=true
+
+        # Set this to true to allow retro-generation of Nickel Ore.
+        B:retrogen_nickel=false
+
+        # Set this to true to allow retro-generation of Silver Ore.
+        B:retrogen_silver=false
+
+        # Set this to true to allow retro-generation of Uranium Ore.
+        B:retrogen_uranium=false
+    }
+
+    tools {
+        # The amount of base damage an ArmorPiercing Cartridge inflicts
+        D:bulletDamage_AP=10.0
+
+        # The amount of base damage a single part of Buckshot inflicts
+        D:bulletDamage_Buck=2.0
+
+        # The amount of base damage a Casull Cartridge inflicts
+        D:bulletDamage_Casull=10.0
+
+        # The amount of base damage a DragonsBreath Cartridge inflicts
+        D:bulletDamage_Dragon=3.0
+
+        # The amount of base damage a Homing Cartridge inflicts
+        D:bulletDamage_Homing=10.0
+
+        # The amount of base damage a Phial Cartridge inflicts
+        D:bulletDamage_Potion=1.0
+
+        # The amount of damage a silver bullet inflicts
+        D:bulletDamage_Silver=10.0
+
+        # The amount of base damage a Wolfpack Cartridge inflicts
+        D:bulletDamage_Wolfpack=6.0
+
+        # The amount of damage the sub-projectiles of the Wolfpack Cartridge inflict
+        D:bulletDamage_WolfpackPart=4.0
+
+        # The mb of fluid the Chemical Thrower will consume per tick of usage
+        I:chemthrower_consumption=10
+
+        # Set this to false to disable the use of Sneak+Scroll to switch Chemthrower tanks.
+        B:chemthrower_scroll=true
+
+        # The maximum durability of the Wirecutter. Used up when cutting plates into wire.
+        I:cutterDurabiliy=250
+
+        # Set this to true to completely disable the ore-crushing recipes with the Engineers Hammer
+        B:disableHammerCrushing=false
+
+        # A list of sounds that should not be muffled by the Ear Defenders. Adding to this list requires knowledge of the correct sound resource names.
+        S:earDefenders_SoundBlacklist <
+         >
+
+        # The maximum durability of the Engineer's Hammer. Used up when hammering ingots into plates.
+        I:hammerDurabiliy=100
+
+        # A blacklist of armor pieces to allow attaching the capacitor backpack, formatting: [mod id]:[item name]. Whitelist has priority over this
+        S:powerpack_blacklist <
+            embers:ashen_cloak_chest
+            ic2:batpack
+            ic2:cf_pack
+            ic2:energy_pack
+            ic2:jetpack
+            ic2:jetpack_electric
+            ic2:lappack
+         >
+
+        # A whitelist of armor pieces to allow attaching the capacitor backpack, formatting: [mod id]:[item name]
+        S:powerpack_whitelist <
+         >
+
+        # The base amount of Flux consumed per shot by the Railgun
+        I:railgun_consumption=800
+
+        # A modifier for the damage of all projectiles fired by the Railgun
+        D:railgun_damage=1.0
+
+        # A whitelist of foods allowed in the toolbox, formatting: [mod id]:[item name]
+        S:toolbox_foods <
+         >
+
+        # A whitelist of tools allowed in the toolbox, formatting: [mod id]:[item name]
+        S:toolbox_tools <
+         >
+
+        # A whitelist of wire-related items allowed in the toolbox, formatting: [mod id]:[item name]
+        S:toolbox_wiring <
+         >
+    }
+
+}
+
+


### PR DESCRIPTION
Prevents following mods from generating ores:

* ImmersiveEngineering (copper, lead, nickel, silver)
* Forestry (copper, tin)